### PR TITLE
initial commit for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,14 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 - If you just need to log a string, do take the pain and create it as follows: 
 `logger.debug({ log: {message: ‘your string’ } });`
 
+# Testing:
 
+* To test without publishing, go to the `PROJECT_ROOT` directory and run `npm link`. Sample output:
+
+		```
+		$ npm link
+		~/.nvm/versions/v7.10.0/lib/node_modules/sp-json-logger -> ~/path/to/<PROJECT_ROOT>
+		```
+* Now you can create and run tests:
+		* `node test/test.1.js`
+		* `env=local node test/test.1.js`

--- a/test/test.1.js
+++ b/test/test.1.js
@@ -1,0 +1,15 @@
+var logger = require('sp-json-logger');
+
+logger.info({log: { message: "hi"}});
+logger.debug({log: {message: 'Your string here...'}});
+logger.tag('myTagA').debug({log: { message: 'Successfully connected' } });
+
+var planets = {planets: ['mars', 'earth']};
+logger.tag('myTagB').debug({log: {
+    type: 'AUDIT',
+    habitable: planets,
+	}
+});
+
+var error = new Error('the earth is flat');
+logger.error(error);


### PR DESCRIPTION
@yogesh8177 `env=local node test/test.1.js` does not show the output in a user-friendly format. What should be fixed?

cc @harshadyeola 