### PR TITLE
Feature/yogesh/specify parent log object

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ Source: [https://www.npmjs.com/package/bunyan#levels](https://www.npmjs.com/pack
 # Key Notes:
 
 - Use tags wherever applicable i.e `logger.tag(‘TAG’).error(err);`
-- When logging error, pass the err object instance directly i.e rather than doing `logger.error({log: {error: err}})`, do `logger.error(err);` instead. Assuming the format of err object is `{err: {message: 'your message', name: 'some name', stack: 'some stack...'}}`! Bunyan recommends this approach and we have to make sure that it is being followed!
-Source: [https://www.npmjs.com/package/bunyan#recommendedbest-practice-fields](https://www.npmjs.com/package/bunyan#recommendedbest-practice-fields)
 
 # Local environment vs Staging/Production environment:
 
@@ -70,7 +68,7 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 `logger.debug('your string');`
 
 # setParentObjectName('String'):
-- By default, parent log object name is **log**, if you want to set another name, use `logger.setParentObjectName('dump');`. This will set parent object to be dump. This will result in following result: 
+- By default, parent log object name is **log**, if you want to set another name, use `logger.setParentObjectName('dump');`. This will set parent object to be dump. This will result in following result: `eg: logger.debug({arg: 'some arg'});`
 - ` {...{"dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T15:34:12.405Z","v":0}} `
 
 # Testing:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ npm install sp-json-logger
 
 ```js
 var log = require('sp-json-logger');
-log.info({log: { message: "hi"}});
+log.info('hi');
 ```
 **Important:** It is important to have **NAME**, **APPLICATION**, **PROGRAM** and **LANGUAGE** env variables set up before requiring the module!
 
@@ -25,15 +25,14 @@ You need to set the following environment variables for logger to work without o
 
 If logging only string message, use the following format:
 
-`logger.debug({log: {message: 'Your string here...'}});`
+`logger.debug({message: 'Your string here...'});` or `logger.debug('Your string here...');`
 
-Also use `logger.tag('CONNECTION').debug({log: { message: 'Successfully connected' } });`
+Also use `logger.tag('CONNECTION').debug({ message: 'Successfully connected' });`
 If logging a JSON Object, use following format:
 ```js
-logger.tag('AUDIT').debug({log:{
+logger.tag('AUDIT').debug({
 	type: 'TYPE of LOG',  // eg: AUDIT Created
 	objectName: objectValue,
-	}
 });
 ```
 
@@ -53,7 +52,6 @@ Source: [https://www.npmjs.com/package/bunyan#levels](https://www.npmjs.com/pack
 - Use tags wherever applicable i.e `logger.tag(‘TAG’).error(err);`
 - When logging error, pass the err object instance directly i.e rather than doing `logger.error({log: {error: err}})`, do `logger.error(err);` instead. Assuming the format of err object is `{err: {message: 'your message', name: 'some name', stack: 'some stack...'}}`! Bunyan recommends this approach and we have to make sure that it is being followed!
 Source: [https://www.npmjs.com/package/bunyan#recommendedbest-practice-fields](https://www.npmjs.com/package/bunyan#recommendedbest-practice-fields)
-- For logging errors of custom objects, use the syntax: `logger.error({err: customObj});`
 
 # Local environment vs Staging/Production environment:
 
@@ -73,7 +71,7 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 
 # setParentObjectName('String'):
 - By default, parent log object name is **log**, if you want to set another name, use `logger.setParentObjectName('dump');`. This will set parent object to be dump. This will result in following result: 
-` {"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T15:34:12.405Z","v":0} `
+- ` {...{"dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T15:34:12.405Z","v":0}} `
 
 # Testing:
 
@@ -232,7 +230,6 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 
 ```
 - You can also use `parse(boolean)` method for parsing an object containing regex, but it is processing heavy and use it only when you really need to or when you cannot use above method for logging regex!
-eg: `logger.tag('REGEX').parse(true).debug({log: {query: query}});`
 
 - Logging object parse(boolean)
 `var query3 = { sku: /^BA1262$/i };`

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ Source: [https://www.npmjs.com/package/bunyan#levels](https://www.npmjs.com/pack
 
 - Specify name of the logger in the NAME env variable to be meaningful.
 - Use tags wherever applicable i.e `logger.tag(‘TAG’).error(err);`
-- Order version required you to log by explcitly stating parent object name i.e **log** as per following example
+- Order version required you to log by explcitly stating parent object name i.e **log** as per following example:
 
 
 	`logger.debug({log: {message: 'hello world'}});`. 
 
 	Latest version supports
 
-	`logger.debug('hello world');'` syntax.
+	`logger.debug('hello world');` syntax.
 - You can set parent object name by utilizing the method `setParentObjectName('String')` explained below.
 - As far as possible use `logger.tag('TAG');` field to describe the event for which we are logging.
 - If you just need to log a string, you can create it as follows: 
@@ -75,16 +75,33 @@ So during local environment, we can enjoy pretty print. During staging and produ
 
 Important: Pretty print stream is a huge performance overhead, so it is recommended to use it only for local/development environment (if you ever want to modify bunyanLogger.js file inside sp-json-logger module)
 
-# setParentObjectName('String'):
-- By default, parent log object name is **log**, if you want to set another name, use 
+# setParentObjectName('String')
 
-	`logger.setParentObjectName('dump');`. 
+If we are not setting the parent object name, it defaults to `log`. But if we use `setParentObjectName('dump')` then the parent object name will become `dump`.
 
-	This will set parent object to be dump. This will result in following result: 
-	
-	`eg: logger.debug({arg: 'some arg'});`
+Eg: Without `setParentObjectName('String')`
+
 ```
- {...{"dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T15:34:12.405Z","v":0}} 
+logger.info('hello world');
+```
+It will output log as : 
+
+`{..., {log: {message: 'hello world'},... }`
+
+Eg: With `setParentObjectName('String')`
+
+```
+logger.setParentObjectName('dump');
+logger.info('hello world with dump');
+
+# Again calling setParentObjectName('String')
+logger.setParentObjectName('payload');
+logger.info('hello world with payload');
+```
+It will output log as : 
+```
+{..., {dump: {message: 'hello world with dump'},... }
+{..., {payload: {message: 'hello world with payload'},... }
 ```
 
 # Testing:

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Source: [https://www.npmjs.com/package/bunyan#levels](https://www.npmjs.com/pack
 - Order version required you to log by explcitly stating parent object name i.e **log** as per following example
 
 
-		`logger.debug({log: {message: 'hello world'}});`. 
+	`logger.debug({log: {message: 'hello world'}});`. 
 
 	Latest version supports
 
-		`logger.debug('hello world');'` syntax.
+	`logger.debug('hello world');'` syntax.
 - You can set parent object name by utilizing the method `setParentObjectName('String')` explained below.
 - As far as possible use `logger.tag('TAG');` field to describe the event for which we are logging.
 - If you just need to log a string, you can create it as follows: 
@@ -236,9 +236,10 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 		}
 		return value;
 	}
+```
+	Then use this function to stringify object containing regex as below:
 
-	// Then use this function to stringify object containing regex as below:
-
+```
 	var query = { sku: /^BA1262$/i };
 	logger.tag('Regex').debug({ query: JSON.stringify(query, replacer) });  // use the utility method replacer!
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 - Specify name of the logger in the NAME env variable to be meaningful.
 - As far as possible use `logger.tag('TAG');` field to describe the event for which we are logging.
 - If you just need to log a string, do take the pain and create it as follows: 
-`logger.debug({ log: {message: 'your string' } });`
+`logger.debug('your string');`
+
+# setParentObjectName('String'):
+- By default, parent log object name is **log**, if you want to set another name, use `logger.setParentObjectName('dump');`. This will set parent object to be dump. This will result in following result: 
+` {"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T15:34:12.405Z","v":0} `
 
 # Testing:
 
@@ -114,7 +118,6 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":50,"application":"","program":"","language":"","err":{"message":"the earth is round :p","name":"discovery","stack":"Some stack here....."},"msg":"the earth is round :p","time":"2017-10-26T15:34:12.404Z","v":0}
 
 
-		Using correct format below logger.error({err: object}), thus name isn't overriden
 		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":30,"application":"","program":"","language":"","dump":{"message":"Hi...."},"tag":"ParentObject name changed","msg":"","time":"2017-10-26T15:34:12.404Z","v":0}
 		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T15:34:12.405Z","v":0}
 		```
@@ -222,11 +225,11 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 - You can also use `parse(boolean)` method for parsing an object containing regex, but it is processing heavy and use it only when you really need to or when you cannot use above method for logging regex!
 eg: `logger.tag('REGEX').parse(true).debug({log: {query: query}});`
 
-Logging object parse(boolean)
+- Logging object parse(boolean)
 `var query3 = { sku: /^BA1262$/i };`
 `logger.parse(true).tag('parse(boolean)').debug(query3);`
 
-Logging regex array with parse(boolean)
+- Logging regex array with parse(boolean)
 `var query4 = { query: [{ sku: /^BA1262$/i }, {sku: /^BRAT$/i}] };`
 `logger.parse(true).tag('RegExArray parse(boolean)').debug(query4);`
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 
 # Testing:
 
-@TODO: Awaiting Harshad's approval for the Elasticsearch - Logstash - Kibana config! It is working as expected, using http driver to push logs to logstash. Created a custom stream for sp-json-logger (test/utils/logstashStream.js) for handling data transfer between logger and logstash!
-
 * To test without publishing, go to the `PROJECT_ROOT` directory and run `npm link`. Sample output:
 
 	```

--- a/README.md
+++ b/README.md
@@ -105,44 +105,37 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 	* `node test/test.local.1.js`
 
 		```
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":30,"application":"","program":"","language":"","log":{"message":"hi"},"msg":"","time":"2017-10-26T15:34:12.391Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","log":{"message":"Your string here..."},"msg":"","time":"2017-10-26T15:34:12.394Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","log":{"message":"Successfully connected"},"tag":"myTagA","msg":"","time":"2017-10-26T15:34:12.396Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","log":{"type":"AUDIT","habitable":{"planets":["mars","earth"]}},"tag":"myTagB","msg":"","time":"2017-10-26T15:34:12.396Z","v":0}
-
-		Regex with JSON.stingify(object, replacer)
-
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","log":{"query":"{\"sku\":\"/^BA1262$/i\"}"},"tag":"Regex","msg":"","time":"2017-10-26T15:34:12.402Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","log":{"query":"{\"query\":[{\"sku\":\"/^BA1262$/i\"},{\"sku\":\"/^BRAT$/i\"}]}"},"tag":"RegExArray","msg":"","time":"2017-10-26T15:34:12.402Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":50,"application":"","program":"","language":"","err":{"message":"the earth is flat","name":"Error","stack":"Error: the earth is flat\n    at Object.<anonymous> (/Users/yogeshjadhav/Documents/sp-json-logger/test/test.local.1.js:25:13)\n    at Module._compile (module.js:570:32)\n    at Object.Module._extensions..js (module.js:579:10)\n    at Module.load (module.js:487:32)\n    at tryModuleLoad (module.js:446:12)\n    at Function.Module._load (module.js:438:3)\n    at Module.runMain (module.js:604:10)\n    at run (bootstrap_node.js:389:7)\n    at startup (bootstrap_node.js:149:9)\n    at bootstrap_node.js:504:3"},"msg":"the earth is flat","time":"2017-10-26T15:34:12.404Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":50,"application":"","program":"","language":"","err":{"message":"the earth is round :p","name":"discovery","stack":"Some stack here....."},"msg":"the earth is round :p","time":"2017-10-26T15:34:12.404Z","v":0}
-
-
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":30,"application":"","program":"","language":"","dump":{"message":"Hi...."},"tag":"ParentObject name changed","msg":"","time":"2017-10-26T15:34:12.404Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T15:34:12.405Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":49588,"level":20,"application":"","program":"","language":"","log":{"query":"{\"sku\":\"/^BA1262$/i\"}"},"tag":"Regex","msg":"","time":"2017-10-26T16:31:40.729Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":49588,"level":20,"application":"","program":"","language":"","log":{"query":"{\"query\":[{\"sku\":\"/^BA1262$/i\"},{\"sku\":\"/^BRAT$/i\"}]}"},"tag":"RegExArray","msg":"","time":"2017-10-26T16:31:40.730Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":49588,"level":20,"application":"","program":"","language":"","log":{"sku":"/^BA1262$/i"},"tag":"parse(boolean)","msg":"","time":"2017-10-26T16:31:40.730Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":49588,"level":20,"application":"","program":"","language":"","log":{"query":[{"sku":"/^BA1262$/i"},{"sku":"/^BRAT$/i"}]},"tag":"RegExArray parse(boolean)","msg":"","time":"2017-10-26T16:31:40.730Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":49588,"level":50,"application":"","program":"","language":"","err":{"message":"the earth is flat","name":"Error","stack":"Error: the earth is flat\n    at Object.<anonymous> (/Users/yogeshjadhav/Documents/sp-json-logger/test/test.local.1.js:34:13)\n    at Module._compile (module.js:570:32)\n    at Object.Module._extensions..js (module.js:579:10)\n    at Module.load (module.js:487:32)\n    at tryModuleLoad (module.js:446:12)\n    at Function.Module._load (module.js:438:3)\n    at Module.runMain (module.js:604:10)\n    at run (bootstrap_node.js:389:7)\n    at startup (bootstrap_node.js:149:9)\n    at bootstrap_node.js:504:3"},"msg":"the earth is flat","time":"2017-10-26T16:31:40.732Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":49588,"level":50,"application":"","program":"","language":"","err":{"message":"the earth is round :p","name":"discovery","stack":"Some stack here....."},"msg":"the earth is round :p","time":"2017-10-26T16:31:40.733Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":49588,"level":30,"application":"","program":"","language":"","dump":{"message":"Hi...."},"tag":"ParentObject name changed","msg":"","time":"2017-10-26T16:31:40.733Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":49588,"level":20,"application":"","program":"","language":"","dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T16:31:40.733Z","v":0}
 		```
 	* `NODE_ENV=local node test/test.local.1.js`
 
 		```
-		[2017-10-26T15:39:04.448Z]  INFO: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
+		[2017-10-26T16:32:42.988Z]  INFO: sp-json-logger/49590 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
 
 			--
 			log: {
 			"message": "hi"
 			}
-		[2017-10-26T15:39:04.453Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
+		[2017-10-26T16:32:42.999Z] DEBUG: sp-json-logger/49590 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
 
 			--
 			log: {
 			"message": "Your string here..."
 			}
-		[2017-10-26T15:39:04.454Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=myTagA)
+		[2017-10-26T16:32:43.001Z] DEBUG: sp-json-logger/49590 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=myTagA)
 
 			--
 			log: {
 			"message": "Successfully connected"
 			}
-		[2017-10-26T15:39:04.455Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=myTagB)
+		[2017-10-26T16:32:43.001Z] DEBUG: sp-json-logger/49590 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=myTagB)
 
 			--
 			log: {
@@ -157,21 +150,40 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 
 		Regex with JSON.stingify(object, replacer)
 
-		[2017-10-26T15:39:04.460Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=Regex)
+		[2017-10-26T16:32:43.011Z] DEBUG: sp-json-logger/49590 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=Regex)
 
 			--
 			log: {
 			"query": "{\"sku\":\"/^BA1262$/i\"}"
 			}
-		[2017-10-26T15:39:04.460Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=RegExArray)
+		[2017-10-26T16:32:43.011Z] DEBUG: sp-json-logger/49590 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=RegExArray)
 
 			--
 			log: {
 			"query": "{\"query\":[{\"sku\":\"/^BA1262$/i\"},{\"sku\":\"/^BRAT$/i\"}]}"
 			}
-		[2017-10-26T15:39:04.463Z] ERROR: sp-json-logger/48472 on Yogeshs-MacBook-Air.local: the earth is flat (application="", program="", language="")
+		[2017-10-26T16:32:43.012Z] DEBUG: sp-json-logger/49590 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=parse(boolean))
+
+			--
+			log: {
+			"sku": "/^BA1262$/i"
+			}
+		[2017-10-26T16:32:43.012Z] DEBUG: sp-json-logger/49590 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag="RegExArray parse(boolean)")
+
+			--
+			log: {
+			"query": [
+				{
+				"sku": "/^BA1262$/i"
+				},
+				{
+				"sku": "/^BRAT$/i"
+				}
+			]
+			}
+		[2017-10-26T16:32:43.014Z] ERROR: sp-json-logger/49590 on Yogeshs-MacBook-Air.local: the earth is flat (application="", program="", language="")
 			Error: the earth is flat
-				at Object.<anonymous> (/Users/yogeshjadhav/Documents/sp-json-logger/test/test.local.1.js:25:13)
+				at Object.<anonymous> (/Users/yogeshjadhav/Documents/sp-json-logger/test/test.local.1.js:34:13)
 				at Module._compile (module.js:570:32)
 				at Object.Module._extensions..js (module.js:579:10)
 				at Module.load (module.js:487:32)
@@ -181,18 +193,15 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 				at run (bootstrap_node.js:389:7)
 				at startup (bootstrap_node.js:149:9)
 				at bootstrap_node.js:504:3
-		[2017-10-26T15:39:04.464Z] ERROR: sp-json-logger/48472 on Yogeshs-MacBook-Air.local: the earth is round :p (application="", program="", language="")
+		[2017-10-26T16:32:43.014Z] ERROR: sp-json-logger/49590 on Yogeshs-MacBook-Air.local: the earth is round :p (application="", program="", language="")
 			Some stack here.....
-
-
-		Using correct format below logger.error({err: object}), thus name isn't overriden
-		[2017-10-26T15:39:04.465Z]  INFO: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag="ParentObject name changed")
+		[2017-10-26T16:32:43.015Z]  INFO: sp-json-logger/49590 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag="ParentObject name changed")
 
 			--
 			dump: {
 			"message": "Hi...."
 			}
-		[2017-10-26T15:39:04.466Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
+		[2017-10-26T16:32:43.015Z] DEBUG: sp-json-logger/49590 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
 
 			--
 			dump: {

--- a/README.md
+++ b/README.md
@@ -101,47 +101,45 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 	* `node test/test.local.1.js`
 
 		```
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":19971,"level":30,"application":"","program":"","language":"","log":{"message":"hi"},"msg":"","time":"2017-09-24T19:42:54.636Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":19971,"level":20,"application":"","program":"","language":"","log":{"message":"Your string here..."},"msg":"","time":"2017-09-24T19:42:54.638Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":19971,"level":20,"application":"","program":"","language":"","log":{"message":"Successfully connected"},"tag":"myTagA","msg":"","time":"2017-09-24T19:42:54.639Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":19971,"level":20,"application":"","program":"","language":"","log":{"type":"AUDIT","habitable":{"planets":["mars","earth"]}},"tag":"myTagB","msg":"","time":"2017-09-24T19:42:54.640Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":30,"application":"","program":"","language":"","log":{"message":"hi"},"msg":"","time":"2017-10-26T15:34:12.391Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","log":{"message":"Your string here..."},"msg":"","time":"2017-10-26T15:34:12.394Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","log":{"message":"Successfully connected"},"tag":"myTagA","msg":"","time":"2017-10-26T15:34:12.396Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","log":{"type":"AUDIT","habitable":{"planets":["mars","earth"]}},"tag":"myTagB","msg":"","time":"2017-10-26T15:34:12.396Z","v":0}
 
 		Regex with JSON.stingify(object, replacer)
 
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":19971,"level":20,"application":"","program":"","language":"","log":{"query":"{\"sku\":\"/^BA1262$/i\"}"},"tag":"Regex","msg":"","time":"2017-09-24T19:42:54.645Z","v":0}
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":19971,"level":20,"application":"","program":"","language":"","log":{"query":"{\"query\":[{\"sku\":\"/^BA1262$/i\"},{\"sku\":\"/^BRAT$/i\"}]}"},"tag":"RegExArray","msg":"","time":"2017-09-24T19:42:54.646Z","v":0}
-
-
-		If we use logger.error({message: 'Your message', name: 'error name', stack: 'some stack....'});
-		It will override the bunyan name property, so such usage is discouraged. See below output for such behavior, name property is discovery instead of sp-json-logger
-		{"name":"discovery","hostname":"Yogeshs-MacBook-Air.local","pid":19971,"level":50,"application":"","program":"","language":"","message":"the earth is round :p","msg":"","time":"2017-09-24T19:42:54.646Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","log":{"query":"{\"sku\":\"/^BA1262$/i\"}"},"tag":"Regex","msg":"","time":"2017-10-26T15:34:12.402Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","log":{"query":"{\"query\":[{\"sku\":\"/^BA1262$/i\"},{\"sku\":\"/^BRAT$/i\"}]}"},"tag":"RegExArray","msg":"","time":"2017-10-26T15:34:12.402Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":50,"application":"","program":"","language":"","err":{"message":"the earth is flat","name":"Error","stack":"Error: the earth is flat\n    at Object.<anonymous> (/Users/yogeshjadhav/Documents/sp-json-logger/test/test.local.1.js:25:13)\n    at Module._compile (module.js:570:32)\n    at Object.Module._extensions..js (module.js:579:10)\n    at Module.load (module.js:487:32)\n    at tryModuleLoad (module.js:446:12)\n    at Function.Module._load (module.js:438:3)\n    at Module.runMain (module.js:604:10)\n    at run (bootstrap_node.js:389:7)\n    at startup (bootstrap_node.js:149:9)\n    at bootstrap_node.js:504:3"},"msg":"the earth is flat","time":"2017-10-26T15:34:12.404Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":50,"application":"","program":"","language":"","err":{"message":"the earth is round :p","name":"discovery","stack":"Some stack here....."},"msg":"the earth is round :p","time":"2017-10-26T15:34:12.404Z","v":0}
 
 
 		Using correct format below logger.error({err: object}), thus name isn't overriden
-		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":19971,"level":50,"application":"","program":"","language":"","err":{"message":"the earth is round :p","name":"discovery","stack":"Some stack here....."},"msg":"the earth is round :p","time":"2017-09-24T19:42:54.647Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":30,"application":"","program":"","language":"","dump":{"message":"Hi...."},"tag":"ParentObject name changed","msg":"","time":"2017-10-26T15:34:12.404Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":48412,"level":20,"application":"","program":"","language":"","dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T15:34:12.405Z","v":0}
 		```
 	* `NODE_ENV=local node test/test.local.1.js`
 
 		```
-		[2017-09-24T19:40:38.524Z]  INFO: sp-json-logger/19940 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
+		[2017-10-26T15:39:04.448Z]  INFO: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
 
 			--
 			log: {
 			"message": "hi"
 			}
-		[2017-09-24T19:40:38.529Z] DEBUG: sp-json-logger/19940 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
+		[2017-10-26T15:39:04.453Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
 
 			--
 			log: {
 			"message": "Your string here..."
 			}
-		[2017-09-24T19:40:38.531Z] DEBUG: sp-json-logger/19940 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=myTagA)
+		[2017-10-26T15:39:04.454Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=myTagA)
 
 			--
 			log: {
 			"message": "Successfully connected"
 			}
-		[2017-09-24T19:40:38.531Z] DEBUG: sp-json-logger/19940 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=myTagB)
+		[2017-10-26T15:39:04.455Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=myTagB)
 
 			--
 			log: {
@@ -156,29 +154,47 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 
 		Regex with JSON.stingify(object, replacer)
 
-		[2017-09-24T19:40:38.537Z] DEBUG: sp-json-logger/19940 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=Regex)
+		[2017-10-26T15:39:04.460Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=Regex)
 
 			--
 			log: {
 			"query": "{\"sku\":\"/^BA1262$/i\"}"
 			}
-		[2017-09-24T19:40:38.537Z] DEBUG: sp-json-logger/19940 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=RegExArray)
+		[2017-10-26T15:39:04.460Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=RegExArray)
 
 			--
 			log: {
 			"query": "{\"query\":[{\"sku\":\"/^BA1262$/i\"},{\"sku\":\"/^BRAT$/i\"}]}"
 			}
-
-
-		If we use logger.error({message: 'Your message', name: 'error name', stack: 'some stack....'});
-		It will override the bunyan name property, so such usage is discouraged. See below output for such behavior, name property is discovery instead of sp-json-logger
-		[2017-09-24T19:40:38.538Z] ERROR: discovery/19940 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", message="the earth is round :p")
-
+		[2017-10-26T15:39:04.463Z] ERROR: sp-json-logger/48472 on Yogeshs-MacBook-Air.local: the earth is flat (application="", program="", language="")
+			Error: the earth is flat
+				at Object.<anonymous> (/Users/yogeshjadhav/Documents/sp-json-logger/test/test.local.1.js:25:13)
+				at Module._compile (module.js:570:32)
+				at Object.Module._extensions..js (module.js:579:10)
+				at Module.load (module.js:487:32)
+				at tryModuleLoad (module.js:446:12)
+				at Function.Module._load (module.js:438:3)
+				at Module.runMain (module.js:604:10)
+				at run (bootstrap_node.js:389:7)
+				at startup (bootstrap_node.js:149:9)
+				at bootstrap_node.js:504:3
+		[2017-10-26T15:39:04.464Z] ERROR: sp-json-logger/48472 on Yogeshs-MacBook-Air.local: the earth is round :p (application="", program="", language="")
+			Some stack here.....
 
 
 		Using correct format below logger.error({err: object}), thus name isn't overriden
-		[2017-09-24T19:40:38.539Z] ERROR: sp-json-logger/19940 on Yogeshs-MacBook-Air.local: the earth is round :p (application="", program="", language="")
-			Some stack here.....
+		[2017-10-26T15:39:04.465Z]  INFO: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag="ParentObject name changed")
+
+			--
+			dump: {
+			"message": "Hi...."
+			}
+		[2017-10-26T15:39:04.466Z] DEBUG: sp-json-logger/48472 on Yogeshs-MacBook-Air.local:  (application="", program="", language="")
+
+			--
+			dump: {
+			"arg": "some arg"
+			}
 		```
 
 # Parsing Objects containing RegEx
@@ -196,21 +212,21 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 	// Then use this function to stringify object containing regex as below:
 
 	var query = { sku: /^BA1262$/i };
-	logger.tag('Regex').debug({log: 
-		{
-			query: JSON.stringify(query, replacer)  // use the utility method replacer!
-		}
-	});
+	logger.tag('Regex').debug({ query: JSON.stringify(query, replacer) });  // use the utility method replacer!
 
 	// Checking passing regex with array
 	var query2 = { query: [{ sku: /^BA1262$/i }, {sku: /^BRAT$/i}] } ;
-	logger.tag('RegExArray').debug({log: 
-		{
-			query: JSON.stringify(query2, replacer) 
-		} 
-	});
+	logger.tag('RegExArray').debug({ query: JSON.stringify(query2, replacer) });
 
 ```
 - You can also use `parse(boolean)` method for parsing an object containing regex, but it is processing heavy and use it only when you really need to or when you cannot use above method for logging regex!
 eg: `logger.tag('REGEX').parse(true).debug({log: {query: query}});`
+
+Logging object parse(boolean)
+`var query3 = { sku: /^BA1262$/i };`
+`logger.parse(true).tag('parse(boolean)').debug(query3);`
+
+Logging regex array with parse(boolean)
+`var query4 = { query: [{ sku: /^BA1262$/i }, {sku: /^BRAT$/i}] };`
+`logger.parse(true).tag('RegExArray parse(boolean)').debug(query4);`
 

--- a/README.md
+++ b/README.md
@@ -52,11 +52,18 @@ Source: [https://www.npmjs.com/package/bunyan#levels](https://www.npmjs.com/pack
 - Specify name of the logger in the NAME env variable to be meaningful.
 - Use tags wherever applicable i.e `logger.tag(‘TAG’).error(err);`
 - Order version required you to log by explcitly stating parent object name i.e **log** as per following example
-`logger.debug({log: {message: 'hello world'}});`. Latest version supports `logger.debug('hello world');'` syntax.
+
+
+		`logger.debug({log: {message: 'hello world'}});`. 
+
+	Latest version supports
+
+		`logger.debug('hello world');'` syntax.
 - You can set parent object name by utilizing the method `setParentObjectName('String')` explained below.
 - As far as possible use `logger.tag('TAG');` field to describe the event for which we are logging.
 - If you just need to log a string, you can create it as follows: 
-`logger.debug('your string');`
+
+	`logger.debug('your string');`
 
 # Local environment vs Staging/Production environment:
 
@@ -69,8 +76,16 @@ So during local environment, we can enjoy pretty print. During staging and produ
 Important: Pretty print stream is a huge performance overhead, so it is recommended to use it only for local/development environment (if you ever want to modify bunyanLogger.js file inside sp-json-logger module)
 
 # setParentObjectName('String'):
-- By default, parent log object name is **log**, if you want to set another name, use `logger.setParentObjectName('dump');`. This will set parent object to be dump. This will result in following result: `eg: logger.debug({arg: 'some arg'});`
-- ` {...{"dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T15:34:12.405Z","v":0}} `
+- By default, parent log object name is **log**, if you want to set another name, use 
+
+	`logger.setParentObjectName('dump');`. 
+
+	This will set parent object to be dump. This will result in following result: 
+	
+	`eg: logger.debug({arg: 'some arg'});`
+```
+ {...{"dump":{"arg":"some arg"},"msg":"","time":"2017-10-26T15:34:12.405Z","v":0}} 
+```
 
 # Testing:
 
@@ -82,7 +97,9 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 	```
 * First start logstash and elasticsearch instances
 	* Run the command from root directory: `docker-compose up`
-	* Once logstash, elasticsearch and kibana instances are up and running, build the docker image for tests: `docker build ./ --tag tests`
+	* Once logstash, elasticsearch and kibana instances are up and running, build the docker image for tests: 
+	
+		`docker build ./ --tag tests`
 	* Figure out the default network running the ELK stack:
 
 		```
@@ -90,7 +107,9 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 		NETWORK ID          NAME                    DRIVER              SCOPE
 		009031fa9b3f        spjsonlogger_default    bridge              local
 		```
-	* Attach and run the tests on that network: `docker run --network=spjsonlogger_default tests`
+	* Attach and run the tests on that network: 
+	
+		`docker run --network=spjsonlogger_default tests`
 	* View test results on kibana: `http://localhost:5601`
         * You must run the tests first before coming here if you want to see meaningful data
 		* `Time Filter field name` should be set to `time`
@@ -206,7 +225,9 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 
 # Parsing Objects containing RegEx
 
-- If your logs contain special objects like regex, create a replacer function for `JSON.stringify(object, replacer)` as follows:
+- If your logs contain special objects like regex, create a replacer function for 
+
+	`JSON.stringify(object, replacer)` as follows:
 ```
 	// Replacer function for JSON.stringify() method
 	function replacer(key, value) {
@@ -229,10 +250,15 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 - You can also use `parse(boolean)` method for parsing an object containing regex, but it is processing heavy and use it only when you really need to or when you cannot use above method for logging regex!
 
 - Logging object parse(boolean)
-`var query3 = { sku: /^BA1262$/i };`
-`logger.parse(true).tag('parse(boolean)').debug(query3);`
+
+	```
+	var query3 = { sku: /^BA1262$/i };`
+	logger.parse(true).tag('parse(boolean)').debug(query3);
+	```
 
 - Logging regex array with parse(boolean)
-`var query4 = { query: [{ sku: /^BA1262$/i }, {sku: /^BRAT$/i}] };`
-`logger.parse(true).tag('RegExArray parse(boolean)').debug(query4);`
+	```
+	var query4 = { query: [{ sku: /^BA1262$/i }, {sku: /^BRAT$/i}] };
+	logger.parse(true).tag('RegExArray parse(boolean)').debug(query4);
+	```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,14 @@ Source: [https://www.npmjs.com/package/bunyan#levels](https://www.npmjs.com/pack
 
 # Key Notes:
 
+- Specify name of the logger in the NAME env variable to be meaningful.
 - Use tags wherever applicable i.e `logger.tag(‘TAG’).error(err);`
+- Order version required you to log by explcitly stating parent object name i.e **log** as per following example
+`logger.debug({log: {message: 'hello world'}});`. Latest version supports `logger.debug('hello world');'` syntax.
+- You can set parent object name by utilizing the method `setParentObjectName('String')` explained below.
+- As far as possible use `logger.tag('TAG');` field to describe the event for which we are logging.
+- If you just need to log a string, you can create it as follows: 
+`logger.debug('your string');`
 
 # Local environment vs Staging/Production environment:
 
@@ -60,12 +67,6 @@ Above module provided a new output stream that pretty prints json object to cons
 So during local environment, we can enjoy pretty print. During staging and production, we get normal json output which helps us to reduce the impact of performance for pretty printing.
 
 Important: Pretty print stream is a huge performance overhead, so it is recommended to use it only for local/development environment (if you ever want to modify bunyanLogger.js file inside sp-json-logger module)
-
-# Notes: 
-- Specify name of the logger in the NAME env variable to be meaningful.
-- As far as possible use `logger.tag('TAG');` field to describe the event for which we are logging.
-- If you just need to log a string, do take the pain and create it as follows: 
-`logger.debug('your string');`
 
 # setParentObjectName('String'):
 - By default, parent log object name is **log**, if you want to set another name, use `logger.setParentObjectName('dump');`. This will set parent object to be dump. This will result in following result: `eg: logger.debug({arg: 'some arg'});`

--- a/src/bunyanWrapper.js
+++ b/src/bunyanWrapper.js
@@ -89,6 +89,8 @@ function Logger(config) {
 
   // This method appends program and language properties and also a tag if it is specified 
   this.generateLogJSON = function (payload, state) {
+    if(payload === null)
+      return {};
     
     var log = {};
     if(typeof payload === 'string') {

--- a/src/bunyanWrapper.js
+++ b/src/bunyanWrapper.js
@@ -38,7 +38,7 @@ function Logger(config) {
   }
 
   this.setParentObjectName = function (name) {
-    this.parentObject = name;
+    this.parentObject = name ? name: 'log';
   }
 
   this.parse = function (_shouldParse) {
@@ -115,6 +115,7 @@ function Logger(config) {
   this.resetObjects = function () {
     this.tagLabel = ''; 
     this.shouldParse = false;
+    this.state = constants.STATE_DEFAULT;
   }
 }
 

--- a/src/bunyanWrapper.js
+++ b/src/bunyanWrapper.js
@@ -2,6 +2,7 @@
     Wrapper implementation 
 */
 var bunyan = require('bunyan');
+const constants = require('./utils/constants.js');
 var env = process.env.NODE_ENV;
 var PrettyStream = require('./utils/bunyan-pretty-stream/lib/prettystream');
 
@@ -24,6 +25,7 @@ function Logger(config) {
       ]
     });
 
+  this.parentObject = 'log';
   this.application = process.env.APPLICATION ? process.env.APPLICATION : '';
   this.program = process.env.PROGRAM ? process.env.PROGRAM : '';
   this.language = process.env.LANGUAGE ? process.env.LANGUAGE : '';
@@ -35,6 +37,10 @@ function Logger(config) {
     return this;
   }
 
+  this.setParentObjectName = function (name) {
+    this.parentObject = name;
+  }
+
   this.parse = function (_shouldParse) {
     this.shouldParse = _shouldParse;
     return this;
@@ -42,51 +48,63 @@ function Logger(config) {
 
   // Wrapper method for debug
   this.info = function (payload) {
-    var log = this.generateLogJSON(payload);
+    var log = this.generateLogJSON(payload, constants.STATE_INFO);
     this.bunyanLogger.info(log);
     this.resetObjects();
   }
 
   // Wrapper method for trace
   this.trace = function (payload) {
-    var log = this.generateLogJSON(payload);
+    var log = this.generateLogJSON(payload, constants.STATE_TRACE);
     this.bunyanLogger.trace(log);
     this.resetObjects();
   }
 
   // Wrapper method for debug
   this.debug = function (payload) {
-    var log = this.generateLogJSON(payload);
+    var log = this.generateLogJSON(payload, constants.STATE_DEBUG);
     this.bunyanLogger.debug(log);
     this.resetObjects();
   }
 
   // Wrapper method for error
   this.error = function (payload) {
-    var err = this.generateLogJSON(payload);
+    var err = this.generateLogJSON(payload, constants.STATE_ERROR);
     this.bunyanLogger.error(err);
     this.resetObjects();
   }
 
   this.warn = function (payload) {
-    var log = this.generateLogJSON(payload);
+    var log = this.generateLogJSON(payload, constants.STATE_WARN);
     this.bunyanLogger.warn(log);
     this.resetObjects();
   }
 
   // Wrapper method for fatal
   this.fatal = function (payload) {
-    var log = this.generateLogJSON(payload);
+    var log = this.generateLogJSON(payload, constants.STATE_FATAL);
     this.bunyanLogger.fatal(log);
     this.resetObjects();
   }
 
   // This method appends program and language properties and also a tag if it is specified 
-  this.generateLogJSON = function (payload) {
+  this.generateLogJSON = function (payload, state) {
     
+    var log = {};
+    if(typeof payload === 'string') {
+      log = Object.assign({}, { application: this.application, program: this.program, language: this.language }, 
+        { 
+          [state === constants.STATE_ERROR ? 'err' : this.parentObject]: {message: payload} 
+        });
+    }else if (typeof payload === 'object') {
+      log = Object.assign({}, { application: this.application, program: this.program, language: this.language }, 
+        { 
+          [state === constants.STATE_ERROR ? 'err' : this.parentObject]: payload 
+        });
+    }
+
     if(this.shouldParse)
       expandProperty(payload);
-    var log = Object.assign({}, { application: this.application, program: this.program, language: this.language }, payload);
 
     if(this.tagLabel)
       log.tag = this.tagLabel;
@@ -100,7 +118,7 @@ function Logger(config) {
   }
 }
 
-// Iterate through properties and check if its a regex!
+// Iterate through properties and check if it is a regex!
 function expandProperty(object) {
 
   for(var key in object) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,9 @@
+module.exports = {
+    STATE_DEFAULT: 'DEFAULT',
+    STATE_INFO: 'INFO',
+    STATE_WARN: 'WARN',
+    STATE_ERROR: 'ERROR',
+    STATE_DEBUG: 'DEBUG',
+    STATE_TRACE: 'TRACE',
+    STATE_FATAL: 'FATAL'
+}

--- a/test/test.1.js
+++ b/test/test.1.js
@@ -10,48 +10,59 @@ if(process.env.NODE_ENV !== 'local'){
     });
 }
 
-logger.info({log: { message: "hi"}});
-logger.debug({log: {message: 'Your string here...'}});
-logger.tag('myTagA').debug({log: { message: 'Successfully connected' } });
+logger.info("hi");
+logger.debug({ message: 'Your string here...'});
+logger.tag('myTagA').debug({ message: 'Successfully connected' });
 
 var planets = {planets: ['mars', 'earth']};
-logger.tag('myTagB').debug({log: {
+logger.tag('myTagB').debug({
     type: 'AUDIT',
     habitable: planets,
-	}
 });
 
 console.log('\nRegex with JSON.stingify(object, replacer)\n');
 // checking regex with parse = true
 var query = { sku: /^BA1262$/i };
-logger.tag('Regex').debug({log: {
+logger.tag('Regex').debug({
     query: JSON.stringify(query, replacer)  // use the utility method replacer!
-    }
 });
 
 // Checking passing regex with array
 var query2 = { query: [{ sku: /^BA1262$/i }, {sku: /^BRAT$/i}] } ;
-logger.tag('RegExArray').debug({ log: {
-    query: JSON.stringify(query2, replacer) 
-    } 
+logger.tag('RegExArray').debug({
+    query: JSON.stringify(query2, replacer)
 });
 
-// This does not work due to issue at: https://github.com/trentm/node-bunyan/issues/369
-//var error = new Error('the earth is flat');
-//logger.error(error);
+// Checking object parse(boolean)
+var query3 = { sku: /^BA1262$/i };
+logger.parse(true).tag('parse(boolean)').debug(query3);
 
-// Whereas explicitly stating the object below works with one caveat i.e name property overrides the logger name property!
-console.log("\n\nIf we use logger.error({message: 'Your message', name: 'error name', stack: 'some stack....'});");
-console.log('It will override the bunyan name property, so such usage is discouraged. See below output for such behavior, name property is discovery instead of sp-json-logger');
+// Checking regex array with parse(boolean)
+var query4 = { query: [{ sku: /^BA1262$/i }, {sku: /^BRAT$/i}] } ;
+logger.parse(true).tag('RegExArray parse(boolean)').debug(query4);
+
+// This does not work due to issue at: https://github.com/trentm/node-bunyan/issues/369. 
+// Update: This works as of version: 1.1.0 as we are encapsulating errors inside err object using parentObject property
+var error = new Error('the earth is flat');
+logger.error(error);
+
 var explicitError = new Error();
 explicitError.message = 'the earth is round :p';
 explicitError.name = 'discovery';   
 explicitError.stack = 'Some stack here.....';
 logger.error(explicitError);
 
-console.log("\n\nUsing correct format below logger.error({err: object}), thus name isn't overriden");
+//console.log("\n\nUsing correct format below logger.error({err: object}), thus name isn't overriden");
 // It is therefore recommended to use the following format! This way we don't override name property of bunyan.
-logger.error({err: explicitError});
+// Update: No longer need to use below format as of version 1.1.0
+//logger.error({err: explicitError}});
+
+/* Version 1.1.0 */
+logger.setParentObjectName('dump');
+
+logger.tag('ParentObject name changed').info('Hi....');
+logger.debug({arg: 'some arg'});
+
 
 /*
     utility functions

--- a/test/test.local.1.js
+++ b/test/test.local.1.js
@@ -40,7 +40,7 @@ explicitError.name = 'discovery';
 explicitError.stack = 'Some stack here.....';
 logger.error(explicitError);
 
-console.log("\n\nUsing correct format below logger.error({err: object}), thus name isn't overriden");
+//console.log("\n\nUsing correct format below logger.error({err: object}), thus name isn't overriden");
 // It is therefore recommended to use the following format! This way we don't override name property of bunyan. *This statement doesn't apply to version 1.1.0*
 // Update: No longer need to use below format as of version 1.1.0
 //logger.error({err: explicitError}});

--- a/test/test.local.1.js
+++ b/test/test.local.1.js
@@ -1,39 +1,39 @@
 var logger = require('./../src/bunyanWrapper');
 
 
-logger.info({log: { message: "hi"}});
-logger.debug({log: {message: 'Your string here...'}});
-logger.tag('myTagA').debug({log: { message: 'Successfully connected' }});
+logger.info("hi");
+logger.debug({message: 'Your string here...'});
+logger.tag('myTagA').debug({ message: 'Successfully connected' });
 
 var planets = {planets: ['mars', 'earth']};
-logger.tag('myTagB').debug({log: {
+logger.tag('myTagB').debug({
     type: 'AUDIT',
     habitable: planets,
-	}
 });
 
 console.log('\nRegex with JSON.stingify(object, replacer)\n');
 // checking regex with parse = true
 var query = { sku: /^BA1262$/i };
-logger.tag('Regex').debug({log: {
-    query: JSON.stringify(query, replacer)  // use the utility method replacer!
-    }
-});
+logger.tag('Regex').debug({ query: JSON.stringify(query, replacer) }); // use the utility method replacer!
+
 
 // Checking passing regex with array
 var query2 = { query: [{ sku: /^BA1262$/i }, {sku: /^BRAT$/i}] } ;
-logger.tag('RegExArray').debug({ log: {
-    query: JSON.stringify(query2, replacer) 
-    } 
-});
+logger.tag('RegExArray').debug({ query: JSON.stringify(query2, replacer) });
 
-// This does not work due to issue at: https://github.com/trentm/node-bunyan/issues/369
-//var error = new Error('the earth is flat');
-//logger.error(error);
+// Checking object parse(boolean)
+var query3 = { sku: /^BA1262$/i };
+logger.parse(true).tag('parse(boolean)').debug(query3);
 
-// Whereas explicitly stating the object below works with one caveat i.e name property overrides the logger name property!
-console.log("\n\nIf we use logger.error({message: 'Your message', name: 'error name', stack: 'some stack....'});");
-console.log('It will override the bunyan name property, so such usage is discouraged. See below output for such behavior, name property is discovery instead of sp-json-logger');
+// Checking regex array with parse(boolean)
+var query4 = { query: [{ sku: /^BA1262$/i }, {sku: /^BRAT$/i}] } ;
+logger.parse(true).tag('RegExArray parse(boolean)').debug(query4);
+
+// This does not work due to issue at: https://github.com/trentm/node-bunyan/issues/369. 
+// Update: This works as of version: 1.1.0 as we are encapsulating errors inside err object using parentObject property
+var error = new Error('the earth is flat');
+logger.error(error);
+
 var explicitError = new Error();
 explicitError.message = 'the earth is round :p';
 explicitError.name = 'discovery';   
@@ -41,16 +41,22 @@ explicitError.stack = 'Some stack here.....';
 logger.error(explicitError);
 
 console.log("\n\nUsing correct format below logger.error({err: object}), thus name isn't overriden");
-// It is therefore recommended to use the following format! This way we don't override name property of bunyan.
-logger.error({err: explicitError});
+// It is therefore recommended to use the following format! This way we don't override name property of bunyan. *This statement doesn't apply to version 1.1.0*
+// Update: No longer need to use below format as of version 1.1.0
+//logger.error({err: explicitError}});
 
+/* Version 1.1.0 */
+logger.setParentObjectName('dump');
+
+logger.tag('ParentObject name changed').info('Hi....');
+logger.debug({arg: 'some arg'});
 
 /*
     utility functions
 */
 
 function replacer(key, value) {
-    if(value instanceof RegExp){
+    if(value instanceof RegExp) {
         return value.toString();
     }
     return value;


### PR DESCRIPTION
Introducing new syntax for making life of a developer easy!
No need to explicitly write a parent object name while logging. Introduced `setParentObjectName('String')` method for the same.

Eg: Older Version
```
logger.debug({log: {message: 'hello world'} });
logger.debug({log: {messageId: mId} });
```
Newer Version

```
logger.debug('hello world');
logger.debug({messageId: mId});
```

# Using setParentObjectName('String')

If we are not setting the parent object name, it defaults to `log`. But if we use `setParentObjectName('dump')` then the parent object name will become `dump`.

Eg: Without `setParentObjectName('String')`

```
logger.info('hello world');
```
It will output log as : 

`{..., {log: {message: 'hello world'},... }`

Eg: With `setParentObjectName('String')`

```
logger.setParentObjectName('dump');
logger.info('hello world with dump');

# Again calling setParentObjectName('String')
logger.setParentObjectName('payload');
logger.info('hello world with payload');
```
It will output log as : 
```
{..., {dump: {message: 'hello world with dump'},... }
{..., {payload: {message: 'hello world with payload'},... }
```
