### PR TITLE
feature to pass custom string only message to error method

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,15 @@ Source: [https://www.npmjs.com/package/bunyan#levels](https://www.npmjs.com/pack
 - Order version required you to log by explcitly stating parent object name i.e **log** as per following example:
 
 
-	`logger.debug({log: {message: 'hello world'}});`. 
-
-	Latest version supports
-
-	`logger.debug('hello world');` syntax.
+```js
+// Older version (1.0.9)
+logger.debug({log: {message: 'hello world'}});
+// Newer version
+logger.debug('hello world');
+logger.debug({message: 'hello world'});
+logger.error('hello world');
+logger.error({message: 'hello world'});
+```
 - You can set parent object name by utilizing the method `setParentObjectName('String')` explained below.
 - As far as possible use `logger.tag('TAG');` field to describe the event for which we are logging.
 - If you just need to log a string, you can create it as follows: 
@@ -134,6 +138,7 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
 		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":29062,"level":50,"application":"","program":"","language":"","err":{"message":"the earth is round :p","name":"discovery","stack":"Some stack here....."},"log":{"message":"My custom error message","functionName":"hello()"
 		},"fileName":"/Users/yogeshjadhav/Documents/sp-json-logger/test/test.local.1.js","msg":"the earth is round :p","time":"2018-03-28T18:22:45.949Z","v":0}
 		{"name":"sp-json-logger","hostname":"3076905ec882","pid":5,"level":50,"application":"tests","program":"sp-json-logger","language":"javascript","log":{"message":"My custom error message","functionName":"error()"},"tag":"Not-Error-Instance","fileName":"/app/test/test.1.js","msg":"","time":"2018-03-29T09:54:30.393Z","v":0}
+		{"name":"sp-json-logger","hostname":"Yogeshs-MacBook-Air.local","pid":95722,"level":50,"application":"","program":"","language":"","log":{"message":"hello error"},"tag":"Not-Error-Instance","fileName":"/Users/yogeshjadhav/Documents/sp-json-logger/test/test.local.1.js","msg":"","time":"2018-04-29T11:53:51.606Z","v":0}
 		```
 	* `NODE_ENV=local node test/test.local.1.js`
 
@@ -306,6 +311,13 @@ Important: Pretty print stream is a huge performance overhead, so it is recommen
     	log: {
       	"message": "My custom error message",
       	"functionName": "hello()"
+    	}
+    	--
+    	fileName: /Users/yogeshjadhav/Documents/sp-json-logger/test/test.local.1.js
+		[2018-04-29T11:53:00.841Z] ERROR: sp-json-logger/95687 on Yogeshs-MacBook-Air.local:  (application="", program="", language="", tag=Not-Error-Instance)
+    	--
+    	log: {
+      	"message": "hello error"
     	}
     	--
     	fileName: /Users/yogeshjadhav/Documents/sp-json-logger/test/test.local.1.js

--- a/src/bunyanWrapper.js
+++ b/src/bunyanWrapper.js
@@ -121,7 +121,7 @@ function Logger(config) {
     if (typeof payload === 'string') {
       log = Object.assign({}, { application: this.application, program: this.program, language: this.language },
         {
-          [state === constants.STATE_ERROR ? 'err' : this.parentObject]: { message: payload }
+          [this.parentObject]: { message: payload }
         });
     } else if (typeof payload === 'object') {
       if (state === constants.STATE_ERROR) {

--- a/test/test.1.js
+++ b/test/test.1.js
@@ -82,7 +82,7 @@ logger.error({ message: 'My custom error message', functionName: 'hello()', err:
 
 logger.tag('Not-Error-Instance').error({ message: 'My custom error message', functionName: 'error()'});
 /* Version 2.1.3 */
-logger.tag('Not-Error-Instance').error('hello error');
+logger.tag('Only string').error('hello error');
 
 /*
     utility functions

--- a/test/test.1.js
+++ b/test/test.1.js
@@ -81,6 +81,8 @@ logger.setParentObjectName('log');
 logger.error({ message: 'My custom error message', functionName: 'hello()', err: explicitError});
 
 logger.tag('Not-Error-Instance').error({ message: 'My custom error message', functionName: 'error()'});
+/* Version 2.1.3 */
+logger.tag('Not-Error-Instance').error('hello error');
 
 /*
     utility functions

--- a/test/test.local.1.js
+++ b/test/test.local.1.js
@@ -70,7 +70,7 @@ logger.error({ message: 'My custom error message', functionName: 'hello()', err:
 
 logger.tag('Not-Error-Instance').error({ message: 'My custom error message', functionName: 'hello()'});
 /* Version 2.1.3 */
-logger.tag('Not-Error-Instance').error('hello error');
+logger.tag('Only string').error('hello error');
 
 /*
     utility functions

--- a/test/test.local.1.js
+++ b/test/test.local.1.js
@@ -69,6 +69,9 @@ logger.setParentObjectName('log');
 logger.error({ message: 'My custom error message', functionName: 'hello()', err: explicitError});
 
 logger.tag('Not-Error-Instance').error({ message: 'My custom error message', functionName: 'hello()'});
+/* Version 2.1.3 */
+logger.tag('Not-Error-Instance').error('hello error');
+
 /*
     utility functions
 */


### PR DESCRIPTION
- Patch for supporting only string to be passed to `logger.error('string')` method. If we pass only a string, it will be logged inside the `parentObjectName` which defaults to `log`.
- Example is given below: 
```js
    logger.error('your custom error string');
```
- Above code will output the following:
```json
    {"log": {"msessage": "your custom error string"}}
```
- ***Note:*** Other fields in the logs are skipped for brevity in the above output.
- `err` object will not be present in such a scenario.