### PR TITLE
feature to disable all logs from sp-json-logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You need to set the following environment variables for logger to work without o
 - **PROGRAM:** 'Name of module' // eg: scheduler-worker or scheduler-api
 - **LANGUAGE:** 'Programming language used' // eg: javascript/php/go
 - **NODE_ENV:** 'environment' // note: Pretty print is supported on local environment setting, if using staging or production, you won’t get pretty json output to console.
-
+- **SP_DISABLE_LOGS:** Use this env variable as `SP_DISABLE_LOGS=true` to disable all logs from `sp-json-logger`.
 If logging only string message, use the following format:
 
 `logger.debug({message: 'Your string here...'});` or `logger.debug('Your string here...');`

--- a/src/bunyanWrapper.js
+++ b/src/bunyanWrapper.js
@@ -25,6 +25,11 @@ function Logger(config) {
         }
       ]
     });
+  
+  if (process.env.SP_DISABLE_LOGS === constants.SP_DISABLE_LOGS) {
+    // refer: https://github.com/trentm/node-bunyan/issues/456
+    this.bunyanLogger.level(bunyan.FATAL + 1);
+  }
 
   this.parentObject = 'log';
   this.filterObject = {};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,9 +1,10 @@
 module.exports = {
+    SP_DISABLE_LOGS: 'true',
     STATE_DEFAULT: 'DEFAULT',
     STATE_INFO: 'INFO',
     STATE_WARN: 'WARN',
     STATE_ERROR: 'ERROR',
     STATE_DEBUG: 'DEBUG',
     STATE_TRACE: 'TRACE',
-    STATE_FATAL: 'FATAL'
+    STATE_FATAL: 'FATAL',
 }


### PR DESCRIPTION
1. Disables all the logs from `sp-json-logger`
1. To test it out locally, run `SP_DISABLE_LOGS=true node test/test.local.1.js` once inside `PROJECT_ROOT`. 
It will result in no logs being displayed from `sp-json-logger`, but if you encounter `Regex with JSON.stingify(object, replacer)`, that log is printed through `console.log`.